### PR TITLE
Actualización: Expo SDK 54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,37 +9,37 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/roboto": "^0.3.0",
-        "@react-native-async-storage/async-storage": "^2.1.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/native-stack": "^7.3.13",
         "axios": "^1.3.5",
-        "expo": "~53.0.9",
-        "expo-font": "~13.3.1",
-        "expo-status-bar": "~2.2.3",
+        "expo": "~54.0.8",
+        "expo-font": "~14.0.8",
+        "expo-status-bar": "~3.0.8",
         "formik": "^2.4.6",
-        "react": "19.0.0",
-        "react-native": "0.79.2",
-        "react-native-gesture-handler": "^2.25.0",
+        "react": "19.1.0",
+        "react-native": "0.81.4",
+        "react-native-gesture-handler": "~2.28.0",
         "react-native-loading-spinner-overlay": "^3.0.1",
         "react-native-paper": "^5.14.3",
-        "react-native-reanimated": "^3.17.5",
-        "react-native-safe-area-context": "^5.4.0",
-        "react-native-screens": "^4.10.0",
+        "react-native-reanimated": "~4.1.0",
+        "react-native-safe-area-context": "~5.6.0",
+        "react-native-screens": "~4.16.0",
         "react-native-vector-icons": "^10.2.0",
         "yup": "^1.6.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/color": "^4.2.0",
-        "@types/react": "~19.0.10",
+        "@types/react": "~19.1.3",
         "@types/react-native-vector-icons": "^6.4.18",
-        "typescript": "~5.8.3"
+        "typescript": "~5.9.2"
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.2.tgz",
-      "integrity": "sha512-N2NGsU5FLBhT8NZ+3l2YrzZSHITjNXNuDhC4iDiikv0IujaJ0Xc6xIxQZ/Ek3Cb+rgPjnLHYyJm11tInuJn+cw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -117,15 +117,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -133,12 +133,12 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
-      "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -161,17 +161,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.27.1",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/traverse": "^7.28.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -199,19 +199,28 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
         "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "resolve": "^1.22.10"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -353,14 +362,14 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-      "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+      "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -466,12 +475,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -481,9 +490,9 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.27.1.tgz",
-      "integrity": "sha512-DTxe4LBPrtFdsWzgpmbBKevg3e9PBy+dXRt19kSbucbZvL2uqtdqwwpluL1jfxYE0wIDTFp1nTy/q6gNLsxXrg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.28.0.tgz",
+      "integrity": "sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.27.1",
@@ -807,14 +816,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-      "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -841,9 +850,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.1.tgz",
-      "integrity": "sha512-QEcFlMl9nGTgh1rn2nIeU5bkfb9BAjaQcWbiP4LvKxUot52ABcTkpcyJ7f2Q2U2RuQ84BNLgts3jRme2dTx6Fw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz",
+      "integrity": "sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -869,6 +878,22 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
+      "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.3",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
@@ -908,12 +933,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.1.tgz",
-      "integrity": "sha512-ttDCqhfvpE9emVkXbPD8vyxxh4TWYACVybGkDj+oReOGwnp066ITEivDlLwe0b1R0+evJ13IXQuLNB5w1fhC5Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+      "integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1079,15 +1105,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.2.tgz",
-      "integrity": "sha512-AIUHD7xJ1mCrj3uPozvtngY3s0xpv7Nu7DoUSnzNY6Xam1Cy4rUznR//pvMHOhQ4AvbCexhbqXCtpxGHOGOO6g==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
+      "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.1",
-        "@babel/plugin-transform-parameters": "^7.27.1"
+        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1128,9 +1155,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-      "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1176,9 +1203,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
-      "integrity": "sha512-p9+Vl3yuHPmkirRrg021XiP+EETmPMQTLr6Ayjj85RLNEbb3Eya/4VI0vAdzQG9SEAl2Lnt7fy5lZyMzjYoZQQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+      "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1271,9 +1298,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz",
-      "integrity": "sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
+      "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1286,16 +1313,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.1.tgz",
-      "integrity": "sha512-TqGF3desVsTcp3WrJGj4HfKokfCXCLcHpt4PJF0D8/iT6LPd9RS82Upw3KPeyr6B22Lfd3DO8MVrmp0oRkUDdw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
+      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.11.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.1",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1356,6 +1383,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1464,18 +1492,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1501,9 +1529,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1553,90 +1581,6 @@
       "integrity": "sha512-+/cmb6N/NDsFanV469ri52C/kz0QWYWnNBi9miKLSlTVpA3EJeLro3mmBxmZxH/N9PRRpoFZ6+dmwkOxh/jbZg==",
       "license": "MIT"
     },
-    "node_modules/@expo/cli": {
-      "version": "0.24.13",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.13.tgz",
-      "integrity": "sha512-2LSdbvYs+WmUljnplQXMCUyNzyX4H+F4l8uExfA1hud25Bl5kyaGrx1jjtgNxMTXmfmMjvgBdK798R50imEhkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@0no-co/graphql.web": "^1.0.8",
-        "@babel/runtime": "^7.20.0",
-        "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~11.0.10",
-        "@expo/config-plugins": "~10.0.2",
-        "@expo/devcert": "^1.1.2",
-        "@expo/env": "~1.0.5",
-        "@expo/image-utils": "^0.7.4",
-        "@expo/json-file": "^9.1.4",
-        "@expo/metro-config": "~0.20.14",
-        "@expo/osascript": "^2.2.4",
-        "@expo/package-manager": "^1.8.4",
-        "@expo/plist": "^0.3.4",
-        "@expo/prebuild-config": "^9.0.6",
-        "@expo/spawn-async": "^1.7.2",
-        "@expo/ws-tunnel": "^1.0.1",
-        "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.79.2",
-        "@urql/core": "^5.0.6",
-        "@urql/exchange-retry": "^1.3.0",
-        "accepts": "^1.3.8",
-        "arg": "^5.0.2",
-        "better-opn": "~3.0.2",
-        "bplist-creator": "0.1.0",
-        "bplist-parser": "^0.3.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.3.0",
-        "compression": "^1.7.4",
-        "connect": "^3.7.0",
-        "debug": "^4.3.4",
-        "env-editor": "^0.4.1",
-        "freeport-async": "^2.0.0",
-        "getenv": "^1.0.0",
-        "glob": "^10.4.2",
-        "lan-network": "^0.1.6",
-        "minimatch": "^9.0.0",
-        "node-forge": "^1.3.1",
-        "npm-package-arg": "^11.0.0",
-        "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
-        "pretty-bytes": "^5.6.0",
-        "pretty-format": "^29.7.0",
-        "progress": "^2.0.3",
-        "prompts": "^2.3.2",
-        "qrcode-terminal": "0.11.0",
-        "require-from-string": "^2.0.2",
-        "requireg": "^0.2.2",
-        "resolve": "^1.22.2",
-        "resolve-from": "^5.0.0",
-        "resolve.exports": "^2.0.3",
-        "semver": "^7.6.0",
-        "send": "^0.19.0",
-        "slugify": "^1.3.4",
-        "source-map-support": "~0.5.21",
-        "stacktrace-parser": "^0.1.10",
-        "structured-headers": "^0.4.1",
-        "tar": "^7.4.3",
-        "terminal-link": "^2.1.1",
-        "undici": "^6.18.2",
-        "wrap-ansi": "^7.0.0",
-        "ws": "^8.12.1"
-      },
-      "bin": {
-        "expo-internal": "build/bin/cli"
-      }
-    },
-    "node_modules/@expo/cli/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz",
@@ -1648,17 +1592,17 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "11.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-11.0.10.tgz",
-      "integrity": "sha512-8S8Krr/c5lnl0eF03tA2UGY9rGBhZcbWKz2UWw5dpL/+zstwUmog8oyuuC8aRcn7GiTQLlbBkxcMeT8sOGlhbA==",
+      "version": "12.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.9.tgz",
+      "integrity": "sha512-HiDVVaXYKY57+L1MxSF3TaYjX6zZlGBnuWnOKZG+7mtsLD+aNTtW4bZM0pZqZfoRumyOU0SfTCwT10BWtUUiJQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~10.0.2",
-        "@expo/config-types": "^53.0.4",
-        "@expo/json-file": "^9.1.4",
+        "@expo/config-plugins": "~54.0.1",
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "^10.0.7",
         "deepmerge": "^4.3.1",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "require-from-string": "^2.0.2",
         "resolve-from": "^5.0.0",
@@ -1669,18 +1613,18 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.2.tgz",
-      "integrity": "sha512-TzUn3pPdpwCS0yYaSlZOClgDmCX8N4I2lfgitX5oStqmvpPtB+vqtdyqsVM02fQ2tlJIAqwBW+NHaHqqy8Jv7g==",
+      "version": "54.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.1.tgz",
+      "integrity": "sha512-NyBChhiWFL6VqSgU+LzK4R1vC397tEG2XFewVt4oMr4Pnalq/mJxBANQrR+dyV1RHhSyhy06RNiJIkQyngVWeg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^53.0.3",
-        "@expo/json-file": "~9.1.4",
-        "@expo/plist": "^0.3.4",
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "~10.0.7",
+        "@expo/plist": "^0.4.7",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
@@ -1703,9 +1647,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "53.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-53.0.4.tgz",
-      "integrity": "sha512-0s+9vFx83WIToEr0Iwy4CcmiUXa5BgwBmEjylBB2eojX5XAMm9mJvw9KpjAb8m7zq2G0Q6bRbeufkzgbipuNQg==",
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
       "license": "MIT"
     },
     "node_modules/@expo/config/node_modules/@babel/code-frame": {
@@ -1749,31 +1693,53 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@expo/devtools": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@expo/devtools/-/devtools-0.1.7.tgz",
+      "integrity": "sha512-dfIa9qMyXN+0RfU6SN4rKeXZyzKWsnz6xBSDccjL4IRiE+fQ0t84zg0yxgN4t/WK2JU5v6v4fby7W7Crv9gJvA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@expo/env": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-1.0.5.tgz",
-      "integrity": "sha512-dtEZ4CAMaVrFu2+tezhU3FoGWtbzQl50xV+rNJE5lYVRjUflWiZkVHlHkWUlPAwDPifLy4TuissVfScGGPWR5g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.7.tgz",
+      "integrity": "sha512-BNETbLEohk3HQ2LxwwezpG8pq+h7Fs7/vAMP3eAtFT1BCpprLYoBBFZH7gW4aqGfqOcVP4Lc91j014verrYNGg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "debug": "^4.3.4",
         "dotenv": "~16.4.5",
         "dotenv-expand": "~11.0.6",
-        "getenv": "^1.0.0"
+        "getenv": "^2.0.0"
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.12.4.tgz",
-      "integrity": "sha512-HOJVvjiQYVHIouCOfFf4JRrQvBDIV/12GVG2iwbw1iGwmpQVkPgEXa9lN0f2yuS4J3QXHs73wr9jvuCjMmJlfw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.1.tgz",
+      "integrity": "sha512-U1S9DwiapCHQjHdHDDyO/oXsl/1oEHSHZRRkWDDrHgXRUDiAVIySw9Unvvcr118Ee6/x4NmKSZY1X0VagrqmFg==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
         "arg": "^5.0.2",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
         "minimatch": "^9.0.0",
         "p-limit": "^3.1.0",
         "resolve-from": "^5.0.0",
@@ -1796,17 +1762,18 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.7.4.tgz",
-      "integrity": "sha512-LcZ82EJy/t/a1avwIboeZbO6hlw8CvsIRh2k6SWPcAOvW0RqynyKFzUJsvnjWlhUzfBEn4oI7y/Pu5Xkw3KkkA==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.7.tgz",
+      "integrity": "sha512-SXOww4Wq3RVXLyOaXiCCuQFguCDh8mmaHBv54h/R29wGl4jRY8GEyQEx8SypV/iHt1FbzsU/X3Qbcd9afm2W2w==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
         "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0",
         "semver": "^7.6.0",
         "temp-dir": "~2.0.0",
         "unique-string": "~2.0.0"
@@ -1825,9 +1792,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.1.4.tgz",
-      "integrity": "sha512-7Bv86X27fPERGhw8aJEZvRcH9sk+9BenDnEmrI3ZpywKodYSBgc8lX9Y32faNVQ/p0YbDK9zdJ0BfAKNAOyi0A==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
@@ -1843,37 +1810,70 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "node_modules/@expo/metro-config": {
-      "version": "0.20.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.14.tgz",
-      "integrity": "sha512-tYDDubuZycK+NX00XN7BMu73kBur/evOPcKfxc+UBeFfgN2EifOITtdwSUDdRsbtJ2OnXwMY1HfRUG3Lq3l4cw==",
+    "node_modules/@expo/mcp-tunnel": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/mcp-tunnel/-/mcp-tunnel-0.0.7.tgz",
+      "integrity": "sha512-ht8Q1nKtiHobZqkUqt/7awwjW2D59ardP6XDVmGceGjQtoZELVaJDHyMIX+aVG9SZ9aj8+uGlhQYeBi57SZPMA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@babel/parser": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "@expo/config": "~11.0.9",
-        "@expo/env": "~1.0.5",
-        "@expo/json-file": "~9.1.4",
-        "@expo/spawn-async": "^1.7.2",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^1.0.0",
-        "glob": "^10.4.2",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "~1.27.0",
-        "minimatch": "^9.0.0",
-        "postcss": "~8.4.32",
-        "resolve-from": "^5.0.0"
+        "ws": "^8.18.3",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.13.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/mcp-tunnel/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/metro": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/metro/-/metro-0.1.1.tgz",
+      "integrity": "sha512-zvA9BE6myFoCxeiw/q3uE/kVkIwLTy27a+fDoEl7WQ7EvKfFeiXnRVhUplDMLGZIHH8VC38Gay6RBtVhnmOm5w==",
+      "license": "MIT",
+      "dependencies": {
+        "metro": "0.83.1",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-config": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-file-map": "0.83.1",
+        "metro-resolver": "0.83.1",
+        "metro-runtime": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
+        "metro-transform-worker": "0.83.1"
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.2.4.tgz",
-      "integrity": "sha512-Q+Oyj+1pdRiHHpev9YjqfMZzByFH8UhKvSszxa0acTveijjDhQgWrq4e9T/cchBHi0GWZpGczWyiyJkk1wM1dg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.7.tgz",
+      "integrity": "sha512-IClSOXxR0YUFxIriUJVqyYki7lLMIHrrzOaP01yxAL1G8pj2DWV5eW1y5jSzIcIfSCNhtGsshGd1tU/AYup5iQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1884,12 +1884,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.8.4.tgz",
-      "integrity": "sha512-8H8tLga/NS3iS7QaX/NneRPqbObnHvVCfMCo0ShudreOFmvmgqhYjRlkZTRstSyFqefai8ONaT4VmnLHneRYYg==",
+      "version": "1.9.8",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.9.8.tgz",
+      "integrity": "sha512-4/I6OWquKXYnzo38pkISHCOCOXxfeEmu4uDoERq1Ei/9Ur/s9y3kLbAamEkitUkDC7gHk1INxRWEfFNzGbmOrA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^9.1.4",
+        "@expo/json-file": "^10.0.7",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -1898,9 +1898,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.3.4.tgz",
-      "integrity": "sha512-MhBLaUJNe9FQDDU2xhSNS4SAolr6K2wuyi4+A79vYuXLkAoICsbTwcGEQJN5jPY6D9izO/jsXh5k0h+mIWQMdw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -1908,41 +1908,30 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/@expo/prebuild-config": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-9.0.6.tgz",
-      "integrity": "sha512-HDTdlMkTQZ95rd6EpvuLM+xkZV03yGLc38FqI37qKFLJtUN1WnYVaWsuXKoljd1OrVEVsHe6CfqKwaPZ52D56Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~11.0.9",
-        "@expo/config-plugins": "~10.0.2",
-        "@expo/config-types": "^53.0.4",
-        "@expo/image-utils": "^0.7.4",
-        "@expo/json-file": "^9.1.4",
-        "@react-native/normalize-colors": "0.79.2",
-        "debug": "^4.3.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/@expo/schema-utils": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.7.tgz",
+      "integrity": "sha512-jWHoSuwRb5ZczjahrychMJ3GWZu54jK9ulNdh1d4OzAEq672K9E5yOlnlBsfIHWHGzUAT+0CL7Yt1INiXTz68g==",
+      "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
       "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
       "license": "MIT"
+    },
+    "node_modules/@expo/server": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.7.4.tgz",
+      "integrity": "sha512-8bfRzL7h1Qgrmf3auR71sPAcAuxnmNkRJs+8enL8vZi2+hihevLhrayDu7P0A/XGEq7wySAGvBBFfIB00Et/AA==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
     },
     "node_modules/@expo/spawn-async": {
       "version": "1.7.2",
@@ -1961,17 +1950,6 @@
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
-    },
-    "node_modules/@expo/vector-icons": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.1.0.tgz",
-      "integrity": "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": "*",
-        "react": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
@@ -2021,9 +1999,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2269,17 +2247,13 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2291,19 +2265,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2317,9 +2282,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2337,9 +2302,9 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
-      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
@@ -2349,31 +2314,31 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.2.tgz",
-      "integrity": "sha512-5h2Z7/+/HL/0h88s0JHOdRCW4CXMCJoROxqzHqxdrjGL6EBD1DdaB4ZqkCOEVSW4Vjhir5Qb97C8i/MPWEYPtg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
+      "integrity": "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.2.tgz",
-      "integrity": "sha512-d+NB7Uosn2ZWd4O4+7ZkB6q1a+0z2opD/4+Bzhk/Tv6fc5FrSftK2Noqxvo3/bhbdGFVPxf0yvLE8et4W17x/Q==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.4.tgz",
+      "integrity": "sha512-6ztXf2Tl2iWznyI/Da/N2Eqymt0Mnn69GCLnEFxFbNdk0HxHPZBNWU9shTXhsLWOL7HATSqwg/bB1+3kY1q+mA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.79.2"
+        "@react-native/codegen": "0.81.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.2.tgz",
-      "integrity": "sha512-/HNu869oUq4FUXizpiNWrIhucsYZqu0/0spudJEzk9SEKar0EjVDP7zkg/sKK+KccNypDQGW7nFXT8onzvQ3og==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.4.tgz",
+      "integrity": "sha512-VYj0c/cTjQJn/RJ5G6P0L9wuYSbU9yGbPYDHCKstlQZQWkk+L9V8ZDbxdJBTIei9Xl3KPQ1odQ4QaeW+4v+AZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -2417,41 +2382,43 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.79.2",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "@react-native/babel-plugin-codegen": "0.81.4",
+        "babel-plugin-syntax-hermes-parser": "0.29.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.2.tgz",
-      "integrity": "sha512-8JTlGLuLi1p8Jx2N/enwwEd7/2CfrqJpv90Cp77QLRX3VHF2hdyavRIxAmXMwN95k+Me7CUuPtqn2X3IBXOWYg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.4.tgz",
+      "integrity": "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==",
       "license": "MIT",
       "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.29.1",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2492,46 +2459,34 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.2.tgz",
-      "integrity": "sha512-E+YEY2dL+68HyR2iahsZdyBKBUi9QyPyaN9vsnda1jNgCjNpSPk2yAF5cXsho+zKK5ZQna3JSeE1Kbi2IfGJbw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.4.tgz",
+      "integrity": "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.2",
-        "chalk": "^4.0.0",
-        "debug": "^2.2.0",
+        "@react-native/dev-middleware": "0.81.4",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.82.0",
-        "metro-config": "^0.82.0",
-        "metro-core": "^0.82.0",
+        "metro": "^0.83.1",
+        "metro-config": "^0.83.1",
+        "metro-core": "^0.83.1",
         "semver": "^7.1.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@react-native-community/cli": "*"
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "*"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
           "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
         }
       }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
       "version": "7.7.2",
@@ -2546,26 +2501,26 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.2.tgz",
-      "integrity": "sha512-cGmC7X6kju76DopSBNc+PRAEetbd7TWF9J9o84hOp/xL3ahxR2kuxJy0oJX8Eg8oehhGGEXTuMKHzNa3rDBeSg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.81.4.tgz",
+      "integrity": "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.2.tgz",
-      "integrity": "sha512-9q4CpkklsAs1L0Bw8XYCoqqyBSrfRALGEw4/r0EkR38Y/6fVfNfdsjSns0pTLO6h0VpxswK34L/hm4uK3MoLHw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.4.tgz",
+      "integrity": "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.2",
+        "@react-native/debugger-frontend": "0.81.4",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
@@ -2573,23 +2528,8 @@
         "ws": "^6.2.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
       "version": "6.2.3",
@@ -2601,43 +2541,43 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.2.tgz",
-      "integrity": "sha512-6MJFemrwR0bOT0QM+2BxX9k3/pvZQNmJ3Js5pF/6owsA0cUDiCO57otiEU8Fz+UywWEzn1FoQfOfQ8vt2GYmoA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.81.4.tgz",
+      "integrity": "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.2.tgz",
-      "integrity": "sha512-IaY87Ckd4GTPMkO1/Fe8fC1IgIx3vc3q9Tyt/6qS3Mtk9nC0x9q4kSR5t+HHq0/MuvGtu8HpdxXGy5wLaM+zUw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.81.4.tgz",
+      "integrity": "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.2.tgz",
-      "integrity": "sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.4.tgz",
+      "integrity": "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg==",
       "license": "MIT"
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.2.tgz",
-      "integrity": "sha512-9G6ROJeP+rdw9Bvr5ruOlag11ET7j1z/En1riFFNo6W3xZvJY+alCuH1ttm12y9+zBm4n8jwCk4lGhjYaV4dKw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.4.tgz",
+      "integrity": "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
+        "@types/react": "^19.1.0",
         "react": "*",
         "react-native": "*"
       },
@@ -2880,9 +2820,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
-      "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2930,23 +2870,29 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@urql/core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.1.1.tgz",
-      "integrity": "sha512-aGh024z5v2oINGD/In6rAtVKTm4VmQ2TxKQBAtk2ZSME5dunZFcjltw4p5ENQg+5CBhZ3FHMzl0Oa+rwqiWqlg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5",
+        "@0no-co/graphql.web": "^1.0.13",
         "wonka": "^6.3.2"
       }
     },
     "node_modules/@urql/exchange-retry": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.1.tgz",
-      "integrity": "sha512-EEmtFu8JTuwsInqMakhLq+U3qN8ZMd5V3pX44q0EqD2imqTDsa8ikZqJ1schVrN8HljOdN+C08cwZ1/r5uIgLw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.2.tgz",
+      "integrity": "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==",
       "license": "MIT",
       "dependencies": {
-        "@urql/core": "^5.1.1",
+        "@urql/core": "^5.1.2",
         "wonka": "^6.3.2"
       },
       "peerDependencies": {
@@ -2954,9 +2900,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2988,9 +2934,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3190,13 +3136,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -3204,43 +3150,52 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.3",
-        "core-js-compat": "^3.40.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.4"
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "19.1.0-rc.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.3.tgz",
+      "integrity": "sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      }
+    },
     "node_modules/babel-plugin-react-native-web": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.13.tgz",
-      "integrity": "sha512-4hHoto6xaN23LCyZgL9LJZc3olmAxd7b6jDzlZnKXAh4rRAbZRKNBJoOOdp46OBqgy+K0t0guTj5/mhA8inymQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.21.1.tgz",
+      "integrity": "sha512-7XywfJ5QIRMwjOL+pwJt2w47Jmi5fFLvK7/So4fV4jIN6PcRbylCp9/l3cJY4VJbSz3lnWTeHDTD1LKIc1C09Q==",
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.25.1"
+        "hermes-parser": "0.29.1"
       }
     },
     "node_modules/babel-plugin-transform-flow-enums": {
@@ -3276,43 +3231,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-preset-expo": {
-      "version": "13.1.11",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.1.11.tgz",
-      "integrity": "sha512-jigWjvhRVdm9UTPJ1wjLYJ0OJvD5vLZ8YYkEknEl6+9S1JWORO/y3xtHr/hNj5n34nOilZqdXrmNFcqKc8YTsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/preset-react": "^7.22.15",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.79.2",
-        "babel-plugin-react-native-web": "~0.19.13",
-        "babel-plugin-syntax-hermes-parser": "^0.25.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4",
-        "react-refresh": "^0.14.2",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "babel-plugin-react-compiler": "^19.0.0-beta-e993439-20250405"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-react-compiler": {
-          "optional": true
-        }
       }
     },
     "node_modules/babel-preset-jest": {
@@ -3356,6 +3274,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.5.tgz",
+      "integrity": "sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
     },
     "node_modules/better-opn": {
       "version": "3.0.2",
@@ -3405,9 +3332,9 @@
       }
     },
     "node_modules/bplist-parser": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
-      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.x"
@@ -3417,9 +3344,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3438,9 +3365,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3457,9 +3384,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
-        "node-releases": "^2.0.19",
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
         "update-browserslist-db": "^1.1.3"
       },
       "bin": {
@@ -3573,9 +3501,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3818,16 +3746,16 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
@@ -3902,12 +3830,12 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
+      "integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4"
+        "browserslist": "^4.25.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4074,15 +4002,12 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
       "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -4139,9 +4064,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.221",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
+      "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4296,27 +4221,31 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "53.0.9",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.9.tgz",
-      "integrity": "sha512-UFG68aVOpccg3s++S3pbtI3YCQCnlu/TFvhnQ5vaD3vhOox1Uk/f2O2T95jmwA/EvKvetqGj34lys3DNXvPqgQ==",
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.8.tgz",
+      "integrity": "sha512-H4nUVvAczd9ZPWrAR3oXxEr/EkLfPxXg5gBvFgZI4WnGNthehqEYB37urXgj9fvgSBxNaRUkySL4uwr9VB2J8Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.24.13",
-        "@expo/config": "~11.0.10",
-        "@expo/config-plugins": "~10.0.2",
-        "@expo/fingerprint": "0.12.4",
-        "@expo/metro-config": "0.20.14",
-        "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~13.1.11",
-        "expo-asset": "~11.1.5",
-        "expo-constants": "~17.1.6",
-        "expo-file-system": "~18.1.10",
-        "expo-font": "~13.3.1",
-        "expo-keep-awake": "~14.1.4",
-        "expo-modules-autolinking": "2.1.10",
-        "expo-modules-core": "2.3.13",
-        "react-native-edge-to-edge": "1.6.0",
+        "@expo/cli": "54.0.6",
+        "@expo/config": "~12.0.9",
+        "@expo/config-plugins": "~54.0.1",
+        "@expo/devtools": "0.1.7",
+        "@expo/fingerprint": "0.15.1",
+        "@expo/metro": "~0.1.1",
+        "@expo/metro-config": "54.0.3",
+        "@expo/vector-icons": "^15.0.2",
+        "@ungap/structured-clone": "^1.3.0",
+        "babel-preset-expo": "~54.0.1",
+        "expo-asset": "~12.0.8",
+        "expo-constants": "~18.0.9",
+        "expo-file-system": "~19.0.14",
+        "expo-font": "~14.0.8",
+        "expo-keep-awake": "~15.0.7",
+        "expo-modules-autolinking": "3.0.11",
+        "expo-modules-core": "3.0.16",
+        "pretty-format": "^29.7.0",
+        "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
       "bin": {
@@ -4343,14 +4272,13 @@
         }
       }
     },
-    "node_modules/expo-asset": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.5.tgz",
-      "integrity": "sha512-GEQDCqC25uDBoXHEnXeBuwpeXvI+3fRGvtzwwt0ZKKzWaN+TgeF8H7c76p3Zi4DfBMFDcduM0CmOvJX+yCCLUQ==",
+    "node_modules/expo-font": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.8.tgz",
+      "integrity": "sha512-bTUHaJWRZ7ywP8dg3f+wfOwv6RwMV3mWT2CDUIhsK70GjNGlCtiWOCoHsA5Od/esPaVxqc37cCBvQGQRFStRlA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.7.4",
-        "expo-constants": "~17.1.5"
+        "fontfaceobserver": "^2.1.0"
       },
       "peerDependencies": {
         "expo": "*",
@@ -4358,63 +4286,15 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-constants": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.6.tgz",
-      "integrity": "sha512-q5mLvJiLtPcaZ7t2diSOlQ2AyxIO8YMVEJsEfI/ExkGj15JrflNQ7CALEW6IF/uNae/76qI/XcjEuuAyjdaCNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~11.0.9",
-        "@expo/env": "~1.0.5"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-file-system": {
-      "version": "18.1.10",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.10.tgz",
-      "integrity": "sha512-SyaWg+HitScLuyEeSG9gMSDT0hIxbM9jiZjSBP9l9zMnwZjmQwsusE6+7qGiddxJzdOhTP4YGUfvEzeeS0YL3Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-font": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.1.tgz",
-      "integrity": "sha512-d+xrHYvSM9WB42wj8vP9OOFWyxed5R1evphfDb6zYBmC1dA9Hf89FpT7TNFtj2Bk3clTnpmVqQTCYbbA2P3CLg==",
-      "license": "MIT",
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
-      }
-    },
-    "node_modules/expo-keep-awake": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
-      "integrity": "sha512-wU9qOnosy4+U4z/o4h8W9PjPvcFMfZXrlUoKTMBW7F4pLqhkkP/5G4EviPZixv4XWFMjn1ExQ5rV6BX8GwJsWA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
-      }
-    },
     "node_modules/expo-modules-autolinking": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.10.tgz",
-      "integrity": "sha512-k93fzoszrYTKbZ51DSVnewYIGUV6Gi22Su8qySXPFJEfvtDs2NUUNRHBZNKgLHvwc6xPzVC5j7JYbrpXNuY44A==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.11.tgz",
+      "integrity": "sha512-Sz1ptcSZ4mvWJ7Rf1aB6Pe1fuEeIkACPILg2tmXDo3wwLTxPqugitMOePjbBZyvacBDirtDZlMb2A6LQDPVFOg==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
         "commander": "^7.2.0",
-        "find-up": "^5.0.0",
         "glob": "^10.4.2",
         "require-from-string": "^2.0.2",
         "resolve-from": "^5.0.0"
@@ -4424,26 +4304,311 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.3.13.tgz",
-      "integrity": "sha512-vmKHv7tEo2wUQoYDV6grhsLsQfD3DUnew5Up3yNnOE1gHGQE+zhV1SBYqaPMPB12OvpyD1mlfzGhu6r9PODnng==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.16.tgz",
+      "integrity": "sha512-rCxzJiTdeSdqLVmDYYnogxqHS3NB65YTd76tAtSACujN2TQco08/toxCCov+9uULq1NGPxDJnfTkrtGaGWfatQ==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
-      }
-    },
-    "node_modules/expo-status-bar": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.2.3.tgz",
-      "integrity": "sha512-+c8R3AESBoduunxTJ8353SqKAKpxL6DvcD8VKBuh81zzJyUUbfB4CVjr1GufSJEKsMzNPXZU+HJwXx7Xh7lx8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-native-edge-to-edge": "1.6.0",
-        "react-native-is-edge-to-edge": "^1.1.6"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-status-bar": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-3.0.8.tgz",
+      "integrity": "sha512-L248XKPhum7tvREoS1VfE0H6dPCaGtoUWzRsUv7hGKdiB4cus33Rc0sxkWkoQ77wE8stlnUlL5lvmT0oqZ3ZBw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/cli": {
+      "version": "54.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.6.tgz",
+      "integrity": "sha512-BgxJshNqSODb4Rq4q4lHLBVWVL4683Q+PSJ2fd+m3D5Jqd8nu9zGvcq6I/H8AXV/Ux31eIuUgAojPCjW8LRyZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.8",
+        "@expo/code-signing-certificates": "^0.0.5",
+        "@expo/config": "~12.0.9",
+        "@expo/config-plugins": "~54.0.1",
+        "@expo/devcert": "^1.1.2",
+        "@expo/env": "~2.0.7",
+        "@expo/image-utils": "^0.8.7",
+        "@expo/json-file": "^10.0.7",
+        "@expo/mcp-tunnel": "~0.0.7",
+        "@expo/metro": "~0.1.1",
+        "@expo/metro-config": "~54.0.3",
+        "@expo/osascript": "^2.3.7",
+        "@expo/package-manager": "^1.9.8",
+        "@expo/plist": "^0.4.7",
+        "@expo/prebuild-config": "^54.0.3",
+        "@expo/schema-utils": "^0.1.7",
+        "@expo/server": "^0.7.4",
+        "@expo/spawn-async": "^1.7.2",
+        "@expo/ws-tunnel": "^1.0.1",
+        "@expo/xcpretty": "^4.3.0",
+        "@react-native/dev-middleware": "0.81.4",
+        "@urql/core": "^5.0.6",
+        "@urql/exchange-retry": "^1.3.0",
+        "accepts": "^1.3.8",
+        "arg": "^5.0.2",
+        "better-opn": "~3.0.2",
+        "bplist-creator": "0.1.0",
+        "bplist-parser": "^0.3.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.3.0",
+        "compression": "^1.7.4",
+        "connect": "^3.7.0",
+        "debug": "^4.3.4",
+        "env-editor": "^0.4.1",
+        "freeport-async": "^2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "lan-network": "^0.1.6",
+        "minimatch": "^9.0.0",
+        "node-forge": "^1.3.1",
+        "npm-package-arg": "^11.0.0",
+        "ora": "^3.4.0",
+        "picomatch": "^3.0.1",
+        "pretty-bytes": "^5.6.0",
+        "pretty-format": "^29.7.0",
+        "progress": "^2.0.3",
+        "prompts": "^2.3.2",
+        "qrcode-terminal": "0.11.0",
+        "require-from-string": "^2.0.2",
+        "requireg": "^0.2.2",
+        "resolve": "^1.22.2",
+        "resolve-from": "^5.0.0",
+        "resolve.exports": "^2.0.3",
+        "semver": "^7.6.0",
+        "send": "^0.19.0",
+        "slugify": "^1.3.4",
+        "source-map-support": "~0.5.21",
+        "stacktrace-parser": "^0.1.10",
+        "structured-headers": "^0.4.1",
+        "tar": "^7.4.3",
+        "terminal-link": "^2.1.1",
+        "undici": "^6.18.2",
+        "wrap-ansi": "^7.0.0",
+        "ws": "^8.12.1"
+      },
+      "bin": {
+        "expo-internal": "build/bin/cli"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "expo-router": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-router": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
+      "version": "54.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.3.tgz",
+      "integrity": "sha512-okf6Umaz1VniKmm+pA37QHBzB9XlRHvO1Qh3VbUezy07LTkz87kXUW7uLMmrA319WLavWSVORTXeR0jBRihObA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.9",
+        "@expo/config-plugins": "~54.0.1",
+        "@expo/config-types": "^54.0.8",
+        "@expo/image-utils": "^0.8.7",
+        "@expo/json-file": "^10.0.7",
+        "@react-native/normalize-colors": "0.81.4",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/metro-config": {
+      "version": "54.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.3.tgz",
+      "integrity": "sha512-TQ5MKSGFB6zJxi+Yr8VYXQFHzRXgvSJzNsHX1otTqnxjXbptwYiXhljAqGSjr3pByq4+sHX/GifMk6fGgAANmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~12.0.9",
+        "@expo/env": "~2.0.7",
+        "@expo/json-file": "~10.0.7",
+        "@expo/metro": "~0.1.1",
+        "@expo/spawn-async": "^1.7.2",
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "hermes-parser": "^0.29.1",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "minimatch": "^9.0.0",
+        "postcss": "~8.4.32",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo/node_modules/@expo/vector-icons": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.2.tgz",
+      "integrity": "sha512-IiBjg7ZikueuHNf40wSGCf0zS73a3guJLdZzKnDUxsauB8VWPLMeWnRIupc+7cFhLUkqyvyo0jLNlcxG5xPOuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/babel-preset-expo": {
+      "version": "54.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.1.tgz",
+      "integrity": "sha512-ziLpj+I/IxQdblHCpuzcyukTpzunq6h/QFsbWhk5DTd4suqB+Vl0Neacd+e38YeKXBabmxCOv8VJN3qk39Md4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/plugin-proposal-decorators": "^7.12.9",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-preset": "0.81.4",
+        "babel-plugin-react-compiler": "^19.1.0-rc.2",
+        "babel-plugin-react-native-web": "~0.21.0",
+        "babel-plugin-syntax-hermes-parser": "^0.29.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "debug": "^4.3.4",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.0",
+        "expo": "*",
+        "react-refresh": ">=0.14.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/runtime": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo/node_modules/expo-asset": {
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.8.tgz",
+      "integrity": "sha512-jj2U8zw9+7orST2rlQGULYiqPoECOuUyffs2NguGrq84bYbkM041T7TOMXH2raPVJnM9lEAP54ezI6XL+GVYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.7",
+        "expo-constants": "~18.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-constants": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.9.tgz",
+      "integrity": "sha512-sqoXHAOGDcr+M9NlXzj1tGoZyd3zxYDy215W6E0Z0n8fgBaqce9FAYQE2bu5X4G629AYig5go7U6sQz7Pjcm8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.9",
+        "@expo/env": "~2.0.7"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "19.0.14",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.14.tgz",
+      "integrity": "sha512-0CA7O5IYhab11TlxQlJAx0Xm9pdkk/zEHNiW+Hh/T4atWi9U/J38CIp7iNYSrBvy9dC3rJbze5D1ANcKKr4mSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-keep-awake": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.7.tgz",
+      "integrity": "sha512-CgBNcWVPnrIVII5G54QDqoE125l+zmqR4HR8q+MQaCfHet+dYpS5vX5zii/RMayzGN4jPgA4XYIQ28ePKFjHoA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/exponential-backoff": {
@@ -4752,9 +4917,9 @@
       }
     },
     "node_modules/getenv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
-      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4778,6 +4943,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/globals": {
@@ -4856,18 +5033,18 @@
       }
     },
     "node_modules/hermes-estree": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.25.1"
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -4960,6 +5137,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/image-size": {
       "version": "1.2.1",
@@ -5421,9 +5607,9 @@
       }
     },
     "node_modules/lan-network": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.6.tgz",
-      "integrity": "sha512-0qPYjNoD89v+bfhkIqFBYGBAof1xhxLqjX8bkNN1kQdP81UHpZw5TDXgEjwB+X2iCFGQmzF8TRmvg4vQcykyDA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
+      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -5464,12 +5650,12 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
-      "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -5479,22 +5665,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.27.0",
-        "lightningcss-darwin-x64": "1.27.0",
-        "lightningcss-freebsd-x64": "1.27.0",
-        "lightningcss-linux-arm-gnueabihf": "1.27.0",
-        "lightningcss-linux-arm64-gnu": "1.27.0",
-        "lightningcss-linux-arm64-musl": "1.27.0",
-        "lightningcss-linux-x64-gnu": "1.27.0",
-        "lightningcss-linux-x64-musl": "1.27.0",
-        "lightningcss-win32-arm64-msvc": "1.27.0",
-        "lightningcss-win32-x64-msvc": "1.27.0"
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
-      "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
       "cpu": [
         "arm64"
       ],
@@ -5512,9 +5698,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
-      "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
       "cpu": [
         "x64"
       ],
@@ -5532,9 +5718,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
-      "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
       "cpu": [
         "x64"
       ],
@@ -5552,9 +5738,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
-      "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
       "cpu": [
         "arm"
       ],
@@ -5572,9 +5758,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
-      "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
       "cpu": [
         "arm64"
       ],
@@ -5592,9 +5778,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
-      "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
       "cpu": [
         "arm64"
       ],
@@ -5612,9 +5798,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
-      "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
       "cpu": [
         "x64"
       ],
@@ -5632,9 +5818,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
-      "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
       "cpu": [
         "x64"
       ],
@@ -5652,9 +5838,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
-      "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
       "cpu": [
         "arm64"
       ],
@@ -5672,9 +5858,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
-      "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
       "cpu": [
         "x64"
       ],
@@ -5889,9 +6075,9 @@
       "license": "MIT"
     },
     "node_modules/metro": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.3.tgz",
-      "integrity": "sha512-EfSLtuUmfsGk3znJ+zoN8cRLniQo3W1wyA+nJMfpTLdENfbbPnGRTwmKhzRcJIUh9jgkrrF4oRQ5shLtQ2DsUw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.1.tgz",
+      "integrity": "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -5909,24 +6095,24 @@
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.28.1",
+        "hermes-parser": "0.29.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.82.3",
-        "metro-cache": "0.82.3",
-        "metro-cache-key": "0.82.3",
-        "metro-config": "0.82.3",
-        "metro-core": "0.82.3",
-        "metro-file-map": "0.82.3",
-        "metro-resolver": "0.82.3",
-        "metro-runtime": "0.82.3",
-        "metro-source-map": "0.82.3",
-        "metro-symbolicate": "0.82.3",
-        "metro-transform-plugins": "0.82.3",
-        "metro-transform-worker": "0.82.3",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-config": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-file-map": "0.83.1",
+        "metro-resolver": "0.83.1",
+        "metro-runtime": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-symbolicate": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
+        "metro-transform-worker": "0.83.1",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -5939,103 +6125,88 @@
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.3.tgz",
-      "integrity": "sha512-eC0f1MSA8rg7VoNDCYMIAIe5AEgYBskh5W8rIa4RGRdmEOsGlXbAV0AWMYoA7NlIALW/S9b10AcdIwD3n1e50w==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz",
+      "integrity": "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.28.1",
+        "hermes-parser": "0.29.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
-      "license": "MIT"
-    },
-    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.28.1"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.3.tgz",
-      "integrity": "sha512-9zKhicA5GENROeP+iXku1NrI8FegtwEg3iPXHGixkm1Yppkbwsy/3lSHSiJZoT6GkZmxUDjN6sQ5QQ+/p72Msw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.1.tgz",
+      "integrity": "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.82.3"
+        "metro-core": "0.83.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.3.tgz",
-      "integrity": "sha512-dDLTUOJ7YYqGog9kR55InchwnkkHuxBXD765J3hQVWWPCy6xO9uZXZYGX1Y/tIMV8U7Ho1Sve0V13n5rFajrRQ==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.1.tgz",
+      "integrity": "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.3.tgz",
-      "integrity": "sha512-GRG9sBkPvrGXD/Wu3RdEDuWg5NDixF9t0c6Zz9kZ9Aa/aQY+m85JgaCI5HYEV+UzVC/IUFFSpJiMfzQRicppLw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.1.tgz",
+      "integrity": "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.82.3",
-        "metro-cache": "0.82.3",
-        "metro-core": "0.82.3",
-        "metro-runtime": "0.82.3"
+        "metro": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-runtime": "0.83.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.3.tgz",
-      "integrity": "sha512-JQZDdXo3hyLl1pqVT4IKEwcBK+3f11qFXeCjQ1hjVpjMwQLOqSM02J7NC/4DNSBt+qWBxWj6R5Jphcc7+9AEWw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.1.tgz",
+      "integrity": "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.3"
+        "metro-resolver": "0.83.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.3.tgz",
-      "integrity": "sha512-o4wtloAge85MZl85F87FT59R/4tn5GvCvLfYcnzzDB20o2YX9AMxZqswrGMaei/GbD/Win5FrLF/Iq8oetcByA==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.1.tgz",
+      "integrity": "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -6049,51 +6220,51 @@
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.3.tgz",
-      "integrity": "sha512-/3FasOULfHq1P0KPNFy5y28Th5oknPSwEbt9JELVBMAPhUnLqQkCLr4M+RQzKG3aEQN1/mEqenWApFCkk6Nm/Q==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.1.tgz",
+      "integrity": "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.3.tgz",
-      "integrity": "sha512-pdib7UrOM04j/RjWmaqmjjWRiuCbpA8BdUSuXzvBaK0QlNzHkRRDv6kiOGxgQ+UgG+KdbPcJktsW9olqiDhf9w==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.1.tgz",
+      "integrity": "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.3.tgz",
-      "integrity": "sha512-J4SrUUsBy9ire8I2sFuXN5MzPmuBHlx1bjvAjdoo1ecpH2mtS3ubRqVnMotBxuK5+GhrbW0mtg5/46PVXy26cw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.1.tgz",
+      "integrity": "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.3.tgz",
-      "integrity": "sha512-gz7wfjz23rit6ePQ7NKE9x+VOWGKm54vli4wbphR9W+3y0bh6Ad7T0BGH9DUzRAnOnOorewrVEqFmT24mia5sg==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.1.tgz",
+      "integrity": "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -6101,25 +6272,25 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.3",
+        "metro-symbolicate": "0.83.1",
         "nullthrows": "^1.1.1",
-        "ob1": "0.82.3",
+        "ob1": "0.83.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.3.tgz",
-      "integrity": "sha512-WZKhR+QGbwkOLWP1z58Y7BFWUqLVDEEPsSQ5UI5+OWQDAwdtsPU9+sSNoJtD5qRU9qrB2XewQE3lJ2EQRRFJew==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.1.tgz",
+      "integrity": "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.82.3",
+        "metro-source-map": "0.83.1",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -6128,13 +6299,13 @@
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.3.tgz",
-      "integrity": "sha512-s1gVrkhczwMbxZLRSLCJ16K/4Sqx5IhO4sWlL6j0jlIEs1/Drn3JrkUUdQTtgmJS8SBpxmmB66cw7wnz751dVg==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.1.tgz",
+      "integrity": "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -6145,13 +6316,13 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.3.tgz",
-      "integrity": "sha512-z5Y7nYlSlLAEhjFi73uEJh69G5IC6HFZmXFcrxnY+JNlsjT2r0GgsDF4WaQGtarAIt5NP88V8983/PedwNfEcw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.1.tgz",
+      "integrity": "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -6159,17 +6330,17 @@
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.82.3",
-        "metro-babel-transformer": "0.82.3",
-        "metro-cache": "0.82.3",
-        "metro-cache-key": "0.82.3",
-        "metro-minify-terser": "0.82.3",
-        "metro-source-map": "0.82.3",
-        "metro-transform-plugins": "0.82.3",
+        "metro": "0.83.1",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-minify-terser": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro/node_modules/ci-info": {
@@ -6177,42 +6348,6 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
-    },
-    "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
-      "license": "MIT"
-    },
-    "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.28.1"
-      }
-    },
-    "node_modules/metro/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -6413,9 +6548,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -6461,15 +6596,15 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.82.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.3.tgz",
-      "integrity": "sha512-8/SeymYlPMVODpCATHqm+X8eiuvD1GsKVa11n688V4GGgjrM3CRvrbtrYBs4t89LJDkv5CwGYPdqayuY0DmTTA==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.1.tgz",
+      "integrity": "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/object-assign": {
@@ -6494,9 +6629,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7042,43 +7177,22 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.2.tgz",
-      "integrity": "sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+      "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "license": "MIT",
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
-      }
-    },
-    "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-fast-compare": {
@@ -7106,42 +7220,40 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.2.tgz",
-      "integrity": "sha512-AnGzb56JvU5YCL7cAwg10+ewDquzvmgrMddiBM0GAWLwQM/6DJfGd2ZKrMuKKehHerpDDZgG+EY64gk3x3dEkw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
+      "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.2",
-        "@react-native/codegen": "0.79.2",
-        "@react-native/community-cli-plugin": "0.79.2",
-        "@react-native/gradle-plugin": "0.79.2",
-        "@react-native/js-polyfills": "0.79.2",
-        "@react-native/normalize-colors": "0.79.2",
-        "@react-native/virtualized-lists": "0.79.2",
+        "@react-native/assets-registry": "0.81.4",
+        "@react-native/codegen": "0.81.4",
+        "@react-native/community-cli-plugin": "0.81.4",
+        "@react-native/gradle-plugin": "0.81.4",
+        "@react-native/js-polyfills": "0.81.4",
+        "@react-native/normalize-colors": "0.81.4",
+        "@react-native/virtualized-lists": "0.81.4",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "babel-plugin-syntax-hermes-parser": "0.29.1",
         "base64-js": "^1.5.1",
-        "chalk": "^4.0.0",
         "commander": "^12.0.0",
-        "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.82.0",
-        "metro-source-map": "^0.82.0",
+        "metro-runtime": "^0.83.1",
+        "metro-source-map": "^0.83.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^6.1.1",
+        "react-devtools-core": "^6.1.5",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.25.0",
+        "scheduler": "0.26.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
@@ -7152,11 +7264,11 @@
         "react-native": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "^19.0.0"
+        "@types/react": "^19.1.0",
+        "react": "^19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -7164,20 +7276,10 @@
         }
       }
     },
-    "node_modules/react-native-edge-to-edge": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
-      "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.25.0.tgz",
-      "integrity": "sha512-NPjJi6mislXxvjxQPU9IYwBjb1Uejp8GvAbE1Lhh+xMIMEvmgAvVIp5cz1P+xAbV6uYcRRArm278+tEInGOqWg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
@@ -7190,9 +7292,9 @@
       }
     },
     "node_modules/react-native-is-edge-to-edge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
-      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
+      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -7255,34 +7357,37 @@
       "license": "MIT"
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.0.tgz",
+      "integrity": "sha512-L8FqZn8VjZyBaCUMYFyx1Y+T+ZTbblaudpxReOXJ66RnOf52g6UM4Pa/IjwLD1XAw1FUxLRQrtpdjbkEc74FiQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4",
-        "react-native-is-edge-to-edge": "1.1.7"
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-worklets": ">=0.5.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
-      "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
+      "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -7290,12 +7395,13 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.10.0.tgz",
-      "integrity": "sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
+      "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",
+        "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {
@@ -7385,6 +7491,44 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
         "node": ">=10"
       }
@@ -7611,6 +7755,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-workspace-root": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.0.tgz",
@@ -7731,9 +7887,9 @@
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -7944,9 +8100,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7976,18 +8132,6 @@
         "bplist-creator": "0.1.0",
         "bplist-parser": "0.3.1",
         "plist": "^3.0.5"
-      }
-    },
-    "node_modules/simple-plist/node_modules/bplist-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
-      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "1.6.x"
-      },
-      "engines": {
-        "node": ">= 5.10.0"
       }
     },
     "node_modules/simple-swizzle": {
@@ -8198,9 +8342,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8226,9 +8370,9 @@
       }
     },
     "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8387,13 +8531,13 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
-      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -8570,9 +8714,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8948,16 +9092,16 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=8.3.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "utf-8-validate": "^5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -9120,6 +9264,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,31 +10,31 @@
   },
   "dependencies": {
     "@expo-google-fonts/roboto": "^0.3.0",
-    "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/native-stack": "^7.3.13",
     "axios": "^1.3.5",
-    "expo": "~53.0.9",
-    "expo-font": "~13.3.1",
-    "expo-status-bar": "~2.2.3",
+    "expo": "~54.0.8",
+    "expo-font": "~14.0.8",
+    "expo-status-bar": "~3.0.8",
     "formik": "^2.4.6",
-    "react": "19.0.0",
-    "react-native": "0.79.2",
-    "react-native-gesture-handler": "^2.25.0",
+    "react": "19.1.0",
+    "react-native": "0.81.4",
+    "react-native-gesture-handler": "~2.28.0",
     "react-native-loading-spinner-overlay": "^3.0.1",
     "react-native-paper": "^5.14.3",
-    "react-native-reanimated": "^3.17.5",
-    "react-native-safe-area-context": "^5.4.0",
-    "react-native-screens": "^4.10.0",
+    "react-native-reanimated": "~4.1.0",
+    "react-native-safe-area-context": "~5.6.0",
+    "react-native-screens": "~4.16.0",
     "react-native-vector-icons": "^10.2.0",
     "yup": "^1.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/color": "^4.2.0",
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.3",
     "@types/react-native-vector-icons": "^6.4.18",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "private": true
 }


### PR DESCRIPTION
_Expo actualizó recientemente su SDK y la versión actual de Expo Go (SDK 54) ya no abre proyectos con SDK 53. Para mantener la compatibilidad fue necesario subir el proyecto a SDK 54 y alinear las dependencias recomendadas por Expo._

- Se actualiza Expo a SDK 54 para compatibilidad con la versión actual de Expo Go.
- Ajusta dependencias relacionadas (react, react-native, expo-font, etc.) usando expo install
- Actualiza versiones esperadas de @react-native-async-storage/async-storage y typescript

Nota de verificación: npm install + npm run start.